### PR TITLE
fix: length check for parsed URL

### DIFF
--- a/shared/utils/domain.go
+++ b/shared/utils/domain.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	_url "net/url"
 	"strings"
 )
@@ -21,7 +20,6 @@ func GetDomainFromURL(url string) string {
 	}
 
 	domain := parts[len(parts)-2] + "." + parts[len(parts)-1]
-	fmt.Println("AFTER PARTS")
 
 	return domain
 }

--- a/shared/utils/domain.go
+++ b/shared/utils/domain.go
@@ -14,7 +14,6 @@ func GetDomainFromURL(url string) string {
 	}
 
 	parts := strings.Split(u.Hostname(), ".")
-
 	if len(parts) < 2 {
 		return url
 	}

--- a/shared/utils/domain.go
+++ b/shared/utils/domain.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	_url "net/url"
 	"strings"
 )
@@ -14,7 +15,13 @@ func GetDomainFromURL(url string) string {
 	}
 
 	parts := strings.Split(u.Hostname(), ".")
+
+	if len(parts) < 2 {
+		return url
+	}
+
 	domain := parts[len(parts)-2] + "." + parts[len(parts)-1]
+	fmt.Println("AFTER PARTS")
 
 	return domain
 }


### PR DESCRIPTION
Adds a guard for checking the parsed URL length before trying to extract the domain to prevent improperly formatted URLs