### PR TITLE
fix: CODEOWNERS should only use the correct team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
 * @pokt-foundation/gateway-code-owners
-* @rem1niscence


### PR DESCRIPTION
The CODEOWNERS file should only contain 1 entry, i.e. the code-owners team. Any changes to the code ownership needs to be performed through managing the gateway-code-owners team